### PR TITLE
feat: Add a Flag to Choose the Behavior when Multiple Diff Targets are Found

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -6,8 +6,10 @@ resources:
 
 namespace: default
 
-commonLabels:
-  prunable: "true"
+labels:
+- includeSelectors: true
+  pairs:
+    prunable: "true"
 
 images:
 - name: nginx


### PR DESCRIPTION
Specifies the behavior when multiple diff targets are found. The value must be either "error" or "latest". In "latest", the selection is based on `metadata.creationTimestamp`