### PR TITLE
Add --version flag to show realname-diff version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
     binary: kubectl-realname_diff
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/hhiroshell/kubectl-realname-diff/pkg/version.Version={{.Version}}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 SETUP_ENVTEST_VERSION ?= release-0.22
 ENVTEST_K8S_VERSION = 1.34.0
 ENVTEST_ASSETS_DIR = $(TESTBIN_DIR)/k8s/$(ENVTEST_K8S_VERSION)-$(shell go env GOOS)-$(shell go env GOARCH)
+VERSION ?= dev
 
 .PHONY: build
 build:
-	$(GO) build -o $(DIST_DIR)/kubectl-realname_diff cmd/kubectl-realname_diff/main.go
+	$(GO) build -ldflags "-X github.com/hhiroshell/kubectl-realname-diff/pkg/version.Version=$(VERSION)" -o $(DIST_DIR)/kubectl-realname_diff cmd/kubectl-realname_diff/main.go
 
 .PHONY: test
 test: vet fmt lint

--- a/pkg/cmd/realname-diff.go
+++ b/pkg/cmd/realname-diff.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/utils/exec"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/hhiroshell/kubectl-realname-diff/pkg/version"
 )
 
 var (
@@ -67,6 +69,7 @@ func NewCmdRealnameDiff(streams genericclioptions.IOStreams) *cobra.Command {
 		Short:                 "Diff live and local resources ignoring Kustomize hash-suffixes.",
 		Long:                  diffLong,
 		Example:               diffExample,
+		Version:               version.Version,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckDiffErr(options.Complete(factory, cmd))
 			cmdutil.CheckDiffErr(validateArgs(cmd, args))
@@ -79,6 +82,8 @@ func NewCmdRealnameDiff(streams genericclioptions.IOStreams) *cobra.Command {
 			}
 		},
 	}
+	cmd.SetVersionTemplate("Real Name Diff Version: {{.Version}}\n")
+	cmd.Flags().BoolP("version", "v", false, "Version for kubectl-realname-diff")
 
 	configFlags.AddFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&options.selector, "selector", "l", options.selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is set at build time via ldflags.
+// Example: go build -ldflags "-X github.com/hhiroshell/kubectl-realname-diff/pkg/version.Version=v1.0.0"
+var Version = "dev"


### PR DESCRIPTION
  ## Summary
  - Add a `pkg/version` package with a `Version` variable that can be set at build time via ldflags
  - Update goreleaser to inject the version from Git tags during release builds
  - Update Makefile to support `VERSION=x.y.z make build` for local builds (defaults to `dev`)

  ## Test plan
  - [x] Verify `--version` flag outputs correct version: `Real Name Diff Version: dev`
  - [x] Verify `--help` shows version flag with correct description
  - [x] Verify custom version injection works: `VERSION=v1.2.3 make build`
  - [x] Verify all existing tests pass

  🤖 Generated with [Claude Code](https://claude.com/claude-code)